### PR TITLE
예약 취소 시 sms 기능 수정

### DIFF
--- a/xcape-api/src/main/java/com/chadev/xcape/api/controller/ApiRestController.java
+++ b/xcape-api/src/main/java/com/chadev/xcape/api/controller/ApiRestController.java
@@ -10,6 +10,7 @@ import com.chadev.xcape.api.service.ReservationService;
 import com.chadev.xcape.api.util.notification.sms.SmsSender;
 import com.chadev.xcape.core.domain.dto.*;
 import com.chadev.xcape.core.domain.dto.history.ReservationHistoryDto;
+import com.chadev.xcape.core.exception.ApiException;
 import com.chadev.xcape.core.exception.ErrorCode;
 import com.chadev.xcape.core.response.Response;
 import com.chadev.xcape.core.service.CoreAbilityService;
@@ -81,7 +82,7 @@ public class ApiRestController {
     }
 
     @GetMapping("/reservations/{reservationId}")
-    public Response<ReservationDto> getReservation(@PathVariable Long reservationId) {
+    public Response<ReservationDto> getReservation(@PathVariable String reservationId) {
         ReservationDto reservationDto = reservationService.getReservation(reservationId);
 
         return Response.success(reservationDto);
@@ -89,13 +90,13 @@ public class ApiRestController {
 
     // 예약 취소
     @DeleteMapping("/reservations/{reservationId}")
-    public Response<Void> cancelReservation(@PathVariable Long reservationId, @RequestBody ReservationCancelRequest request) {
+    public Response<Void> cancelReservation(@PathVariable String reservationId, @RequestBody ReservationCancelRequest request) {
         ReservationDto reservation = reservationService.getReservation(reservationId);
-        if (Objects.equals(reservation.getPhoneNumber(), request.getRecipientNo())) {
+        if (!Objects.equals(reservation.getPhoneNumber(), request.getRecipientNo())) {
             reservationService.cancelReservationById(reservationId, request.getRequestId(), request.getAuthenticationNumber());
             return Response.success();
         } else {    // 예약 연락처와 인증 연락처 미일치
-            return Response.error(ErrorCode.AUTHENTICATION_INVALID_PHONE_NUMBER.getMessage());
+            throw new ApiException(Integer.parseInt(ErrorCode.AUTHENTICATION_INVALID_PHONE_NUMBER.getCode()), ErrorCode.AUTHENTICATION_INVALID_PHONE_NUMBER.getMessage());
         }
     }
 
@@ -124,7 +125,7 @@ public class ApiRestController {
     }
 
     @PostMapping("/reservations/authentication")
-    public Response<ReservationAuthenticationDto> sms(@RequestBody AuthenticationRequest authenticationRequest) {
+    public Response<ReservationAuthenticationDto> sms(@RequestBody AuthenticationRequest authenticationRequest) throws Exception {
         ReservationAuthenticationDto reservationAuthenticationDto = smsSender.sendAuthenticationSms(authenticationRequest.getReservationId(), authenticationRequest.getRecipientNo());
 
         return Response.success(reservationAuthenticationDto);

--- a/xcape-api/src/main/java/com/chadev/xcape/api/util/notification/sms/SmsSender.java
+++ b/xcape-api/src/main/java/com/chadev/xcape/api/util/notification/sms/SmsSender.java
@@ -35,7 +35,7 @@ public class SmsSender {
     private final ReservationAuthenticationRepository authenticationRepository;
     private final RestTemplate restTemplate;
 
-    public SmsResponse sendSms(SmsRequest request) throws Exception {
+    public SmsResponse sendSms(SmsRequest request) {
         HttpHeaders header = new HttpHeaders();
         header.setContentType(MediaType.APPLICATION_JSON);
         header.set("X-Secret-Key", secretKey);
@@ -50,7 +50,7 @@ public class SmsSender {
         return response.getBody();
     }
 
-    public ReservationAuthenticationDto sendAuthenticationSms(Long reservationId, String recipientNo) throws Exception{
+    public ReservationAuthenticationDto sendAuthenticationSms(Long reservationId, String recipientNo) {
         ReservationAuthenticationDto reservationAuthenticationDto;
 
         SmsRequest request = SmsRequest.authenticate(recipientNo);

--- a/xcape-core/src/main/java/com/chadev/xcape/core/domain/dto/ReservationAuthenticationDto.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/domain/dto/ReservationAuthenticationDto.java
@@ -9,28 +9,24 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Builder
+@AllArgsConstructor
 @Getter
 @Setter
 public class ReservationAuthenticationDto {
 
     private String requestId;
 
-    private Long reservationId;
+    private String reservationId;
 
     private String authenticationNumber;
 
     private LocalDateTime registeredAt;
 
-    public ReservationAuthenticationDto(String requestId, Long reservationId, LocalDateTime registeredAt) {
-        this.requestId = requestId;
-        this.reservationId = reservationId;
-        this.registeredAt = registeredAt;
-    }
-
     public static ReservationAuthenticationDto from(ReservationAuthentication entity) {
         return new ReservationAuthenticationDto(
                 entity.getRequestId(),
                 entity.getReservation().getId(),
+                entity.getAuthenticationNumber(),
                 entity.getRegisteredAt()
         );
     }

--- a/xcape-core/src/main/java/com/chadev/xcape/core/domain/dto/ReservationDto.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/domain/dto/ReservationDto.java
@@ -17,7 +17,9 @@ import java.time.LocalTime;
 public class ReservationDto {
 
     // 기본값
-    private Long id;
+    private String id;
+
+    private Long sequence;
 
     private Long themeId;
 
@@ -67,6 +69,7 @@ public class ReservationDto {
     public static ReservationDto fake(Reservation entity) {
         return new ReservationDto(
                 entity.getId(),
+                entity.getSequence(),
                 entity.getThemeId(),
                 entity.getMerchant().getId(),
                 entity.getThemeName(),

--- a/xcape-core/src/main/java/com/chadev/xcape/core/domain/dto/history/ReservationHistoryDto.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/domain/dto/history/ReservationHistoryDto.java
@@ -2,7 +2,6 @@ package com.chadev.xcape.core.domain.dto.history;
 
 import com.chadev.xcape.core.domain.entity.history.ReservationHistory;
 import com.chadev.xcape.core.domain.type.HistoryType;
-import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +17,7 @@ public class ReservationHistoryDto {
 
     private Long id;
 
-    private Long reservationId;
+    private String reservationId;
 
     private HistoryType type;
 

--- a/xcape-core/src/main/java/com/chadev/xcape/core/domain/entity/Reservation.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/domain/entity/Reservation.java
@@ -19,9 +19,15 @@ public class Reservation extends AuditingFields {
 
     @Setter(AccessLevel.NONE)
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "reservation_id", nullable = false)
-    private Long id;
+    private String id;
+
+    @Setter(AccessLevel.NONE)
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "reservation_sequence", nullable = false)
+    private Long sequence;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "merchant_id")

--- a/xcape-core/src/main/java/com/chadev/xcape/core/exception/ErrorCode.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/exception/ErrorCode.java
@@ -7,20 +7,21 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    NOT_EXISTENT_MERCHANT("존재하지 않는 지점입니다."),
-    NOT_EXISTENT_THEME("존재하지 않는 테마입니다."),
-    NOT_EXISTENT_RESERVATION("존재하지 않는 예약입니다."),
-    NOT_EXISTENT_ABILITY("존재하지 않는 어빌리티입니다."),
-    NOT_EXISTENT_BANNER("존재하지 않는 배너입니다."),
-    NOT_EXISTENT_CLOSED_DATE("존재하지 않는 휴무입니다."),
-    NOT_EXISTENT_PRICE("존재하지 않는 가격정책입니다."),
-    NOT_EXISTENT_RESERVATION_HISTORY("존재하지 않는 예약기록입니다."),
-    NOT_EXISTENT_SCHEDULER("존재하지 않는 스케줄러입니다."),
+    SERVER_ERROR("9000", "서버 에러가 발생했습니다."),
+    NOT_EXISTENT_MERCHANT("9001", "존재하지 않는 지점입니다."),
+    NOT_EXISTENT_THEME("9002", "존재하지 않는 테마입니다."),
+    NOT_EXISTENT_RESERVATION("9003", "존재하지 않는 예약입니다."),
+    NOT_EXISTENT_ABILITY("9004", "존재하지 않는 어빌리티입니다."),
+    NOT_EXISTENT_BANNER("9005", "존재하지 않는 배너입니다."),
+    NOT_EXISTENT_CLOSED_DATE("9006", "존재하지 않는 휴무입니다."),
+    NOT_EXISTENT_PRICE("9007", "존재하지 않는 가격정책입니다."),
+    NOT_EXISTENT_RESERVATION_HISTORY("9008", "존재하지 않는 예약기록입니다."),
+    NOT_EXISTENT_SCHEDULER("9009", "존재하지 않는 스케줄러입니다."),
 
     // 인증
-    AUTHENTICATION_INVALID_PHONE_NUMBER("예약자의 연락처와 일치하지 않는 연락처입니다."),
-    AUTHENTICATION_TIME_OUT("인증 시간이 초과하였습니다."),
-    AUTHENTICATION_INVALID_NUMBER("인증번호가 일치하지 않습니다."),
+    AUTHENTICATION_INVALID_PHONE_NUMBER("9100", "예약자의 연락처와 일치하지 않는 연락처입니다."),
+    AUTHENTICATION_TIME_OUT("9101", "인증 시간이 초과하였습니다."),
+    AUTHENTICATION_INVALID_NUMBER("9102", "인증번호가 일치하지 않습니다."),
     ;
 
 

--- a/xcape-core/src/main/java/com/chadev/xcape/core/exception/XcapeException.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/exception/XcapeException.java
@@ -10,24 +10,15 @@ public class XcapeException extends RuntimeException {
     private ErrorCode errorCode;
     private String message;
 
-    public static XcapeException NOT_EXISTENT_MERCHANT() {
-        return new XcapeException(
-                ErrorCode.NOT_EXISTENT_MERCHANT,
-                ErrorCode.NOT_EXISTENT_MERCHANT.getMessage()
-        );
+    public XcapeException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.message = errorCode.getMessage();
+        this.errorCode = errorCode;
     }
 
-    public static XcapeException NOT_EXISTENT_THEME() {
-        return new XcapeException(
-                ErrorCode.NOT_EXISTENT_THEME,
-                ErrorCode.NOT_EXISTENT_THEME.getMessage()
-        );
-    }
+    public static XcapeException NOT_EXISTENT_MERCHANT() {return new XcapeException(ErrorCode.NOT_EXISTENT_MERCHANT);}
 
-    public static XcapeException NOT_EXISTENT_RESERVATION() {
-        return new XcapeException(
-                ErrorCode.NOT_EXISTENT_RESERVATION,
-                ErrorCode.NOT_EXISTENT_RESERVATION.getMessage()
-        );
-    }
+    public static XcapeException NOT_EXISTENT_THEME() {return new XcapeException(ErrorCode.NOT_EXISTENT_THEME);}
+
+    public static XcapeException NOT_EXISTENT_RESERVATION() {return new XcapeException(ErrorCode.NOT_EXISTENT_RESERVATION);}
 }

--- a/xcape-core/src/main/java/com/chadev/xcape/core/repository/ReservationRepository.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/repository/ReservationRepository.java
@@ -2,7 +2,6 @@ package com.chadev.xcape.core.repository;
 
 import com.chadev.xcape.core.domain.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -12,6 +11,8 @@ import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    Optional<Reservation> findById(String reservationId);
 
     List<Reservation> findByThemeIdAndDate(Long themeId, LocalDate date);
 

--- a/xcape-core/src/main/java/com/chadev/xcape/core/response/Response.java
+++ b/xcape-core/src/main/java/com/chadev/xcape/core/response/Response.java
@@ -1,5 +1,6 @@
 package com.chadev.xcape.core.response;
 
+import com.chadev.xcape.core.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +11,10 @@ public class Response<T> {
     private String resultCode;
     private String resultMessage;
     private T result;
+
+    public static <T> Response<T> error(ErrorCode e) {
+        return new Response<>(e.getCode(), e.getMessage(), null);
+    }
 
     public static <T> Response<T> error(String resultMessage) {
         return new Response<>(ErrorCode.SERVER_ERROR.getCode(), resultMessage, null);


### PR DESCRIPTION
db pk 추가(reservation_id)에 따른 보수작업

TODO: 에러 해결
Caused by: org.hibernate.AnnotationException: An association that targets entity 'com.chadev.xcape.core.domain.entity.Reservation' from entity 'com.chadev.xcape.core.domain.entity.ReservationAuthentication' has 1 '@JoinColumn's but the primary key has 2 columns
	at org.hibernate.cfg.annotations.TableBinder.bindImplicitPkReference(TableBinder.java:617) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.cfg.annotations.TableBinder.bindExplicitColumns(TableBinder.java:597) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.cfg.annotations.TableBinder.bindForeignKey(TableBinder.java:577) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.cfg.ToOneFkSecondPass.doSecondPass(ToOneFkSecondPass.java:101) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.boot.internal.InFlightMetadataCollectorImpl.processEndOfQueue(InFlightMetadataCollectorImpl.java:1879) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.boot.internal.InFlightMetadataCollectorImpl.processFkSecondPassesInOrder(InFlightMetadataCollectorImpl.java:1826) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.boot.internal.InFlightMetadataCollectorImpl.processSecondPasses(InFlightMetadataCollectorImpl.java:1733) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.boot.model.process.spi.MetadataBuildingProcess.complete(MetadataBuildingProcess.java:300) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.metadata(EntityManagerFactoryBuilderImpl.java:1350) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.build(EntityManagerFactoryBuilderImpl.java:1421) ~[hibernate-core-6.1.5.Final.jar:6.1.5.Final]